### PR TITLE
Prevent website text from being selected

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,10 @@ input::-webkit-inner-spin-button {
   margin: 0;
 }
 
+* {
+  user-select: none;
+}
+
 .section {
   @apply relative flex w-full max-w-[1300px] flex-row justify-center
 }


### PR DESCRIPTION
This can apply to various browsers, especially on mobile browsers. This could be helpful when the user is practicing their speed skills in phones and tablets.